### PR TITLE
Use swap hack rather than hidden public API

### DIFF
--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -37,6 +37,7 @@ use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPat
 use bitcoin::consensus::encode;
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::{self, Input, Psbt, PsbtSighashType};
+use bitcoin::script::ScriptBufExt as _;
 use bitcoin::secp256k1::{Secp256k1, Signing, Verification};
 use bitcoin::{
     transaction, Address, Amount, CompressedPublicKey, Network, OutPoint, ScriptBuf, Sequence,

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -84,7 +84,7 @@ use bitcoin::consensus::encode;
 use bitcoin::key::{TapTweak, XOnlyPublicKey};
 use bitcoin::opcodes::all::{OP_CHECKSIG, OP_CLTV, OP_DROP};
 use bitcoin::psbt::{self, Input, Output, Psbt, PsbtSighashType};
-use bitcoin::script::ScriptExt as _;
+use bitcoin::script::{ScriptBufExt as _, ScriptExt as _};
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::sighash::{self, SighashCache, TapSighash, TapSighashType};
 use bitcoin::taproot::{self, LeafVersion, TapLeafHash, TaprootBuilder, TaprootSpendInfo};

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -894,6 +894,7 @@ mod tests {
     use super::*;
     use crate::network::params;
     use crate::network::Network::{Bitcoin, Testnet};
+    use crate::script::ScriptBufExt as _;
 
     fn roundtrips(addr: &Address, network: Network) {
         assert_eq!(

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -7,7 +7,7 @@ use crate::locktime::absolute;
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::prelude::Vec;
-use crate::script::{ScriptExt as _, ScriptExtPriv as _};
+use crate::script::{ScriptBufExt as _, ScriptExt as _, ScriptExtPriv as _};
 use crate::Sequence;
 
 /// An Object which can be used to construct a script piece by piece.

--- a/bitcoin/src/blockdata/script/instruction.rs
+++ b/bitcoin/src/blockdata/script/instruction.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use super::{read_uint_iter, Error, PushBytes, Script, ScriptBuf, UintError};
+use super::{
+    read_uint_iter, Error, PushBytes, Script, ScriptBuf, ScriptBufExtPriv as _, UintError,
+};
 use crate::opcodes::{self, Opcode};
 
 /// A "parsed opcode" which allows iterating over a [`Script`] in a more sensible way.

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -110,6 +110,8 @@ impl ScriptBuf {
     pub fn extend_from_slice(&mut self, other: &[u8]) { self.0.extend_from_slice(other) }
 }
 
+mod tmp_pub {
+    use super::*;
 impl ScriptBuf {
     /// Creates a new script builder
     pub fn builder() -> Builder { Builder::new() }
@@ -172,7 +174,10 @@ impl ScriptBuf {
     /// multiple times.
     pub fn scan_and_push_verify(&mut self) { self.push_verify(self.last_opcode()); }
 }
+}
 
+mod tmp_priv {
+    use super::*;
 impl ScriptBuf {
     /// Pushes the slice without reserving
     pub(in crate::blockdata::script) fn push_slice_no_opt(&mut self, data: &PushBytes) {
@@ -227,6 +232,7 @@ impl ScriptBuf {
             None => self.push_opcode(OP_VERIFY),
         }
     }
+}
 }
 
 impl<'a> core::iter::FromIterator<Instruction<'a>> for ScriptBuf {

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -135,8 +135,47 @@ impl ScriptBuf {
         self.push_slice_no_opt(data);
     }
 
+    /// Add a single instruction to the script.
+    ///
+    /// # Panics
+    ///
+    /// The method panics if the instruction is a data push with length greater or equal to
+    /// 0x100000000.
+    pub fn push_instruction(&mut self, instruction: Instruction<'_>) {
+        match instruction {
+            Instruction::Op(opcode) => self.push_opcode(opcode),
+            Instruction::PushBytes(bytes) => self.push_slice(bytes),
+        }
+    }
+
+    /// Like push_instruction, but avoids calling `reserve` to not re-check the length.
+    pub fn push_instruction_no_opt(&mut self, instruction: Instruction<'_>) {
+        match instruction {
+            Instruction::Op(opcode) => self.push_opcode(opcode),
+            Instruction::PushBytes(bytes) => self.push_slice_no_opt(bytes),
+        }
+    }
+
+    /// Adds an `OP_VERIFY` to the script or replaces the last opcode with VERIFY form.
+    ///
+    /// Some opcodes such as `OP_CHECKSIG` have a verify variant that works as if `VERIFY` was
+    /// in the script right after. To save space this function appends `VERIFY` only if
+    /// the most-recently-added opcode *does not* have an alternate `VERIFY` form. If it does
+    /// the last opcode is replaced. E.g., `OP_CHECKSIG` will become `OP_CHECKSIGVERIFY`.
+    ///
+    /// Note that existing `OP_*VERIFY` opcodes do not lead to the instruction being ignored
+    /// because `OP_VERIFY` consumes an item from the stack so ignoring them would change the
+    /// semantics.
+    ///
+    /// This function needs to iterate over the script to find the last instruction. Prefer
+    /// `Builder` if you're creating the script from scratch or if you want to push `OP_VERIFY`
+    /// multiple times.
+    pub fn scan_and_push_verify(&mut self) { self.push_verify(self.last_opcode()); }
+}
+
+impl ScriptBuf {
     /// Pushes the slice without reserving
-    fn push_slice_no_opt(&mut self, data: &PushBytes) {
+    pub(in crate::blockdata::script) fn push_slice_no_opt(&mut self, data: &PushBytes) {
         // Start with a PUSH opcode
         match data.len().to_u64() {
             n if n < opcodes::Ordinary::OP_PUSHDATA1 as u64 => {
@@ -174,43 +213,6 @@ impl ScriptBuf {
             _ => 5,
         }
     }
-
-    /// Add a single instruction to the script.
-    ///
-    /// # Panics
-    ///
-    /// The method panics if the instruction is a data push with length greater or equal to
-    /// 0x100000000.
-    pub fn push_instruction(&mut self, instruction: Instruction<'_>) {
-        match instruction {
-            Instruction::Op(opcode) => self.push_opcode(opcode),
-            Instruction::PushBytes(bytes) => self.push_slice(bytes),
-        }
-    }
-
-    /// Like push_instruction, but avoids calling `reserve` to not re-check the length.
-    pub fn push_instruction_no_opt(&mut self, instruction: Instruction<'_>) {
-        match instruction {
-            Instruction::Op(opcode) => self.push_opcode(opcode),
-            Instruction::PushBytes(bytes) => self.push_slice_no_opt(bytes),
-        }
-    }
-
-    /// Adds an `OP_VERIFY` to the script or replaces the last opcode with VERIFY form.
-    ///
-    /// Some opcodes such as `OP_CHECKSIG` have a verify variant that works as if `VERIFY` was
-    /// in the script right after. To save space this function appends `VERIFY` only if
-    /// the most-recently-added opcode *does not* have an alternate `VERIFY` form. If it does
-    /// the last opcode is replaced. E.g., `OP_CHECKSIG` will become `OP_CHECKSIGVERIFY`.
-    ///
-    /// Note that existing `OP_*VERIFY` opcodes do not lead to the instruction being ignored
-    /// because `OP_VERIFY` consumes an item from the stack so ignoring them would change the
-    /// semantics.
-    ///
-    /// This function needs to iterate over the script to find the last instruction. Prefer
-    /// `Builder` if you're creating the script from scratch or if you want to push `OP_VERIFY`
-    /// multiple times.
-    pub fn scan_and_push_verify(&mut self) { self.push_verify(self.last_opcode()); }
 
     /// Adds an `OP_VERIFY` to the script or changes the most-recently-added opcode to `VERIFY`
     /// alternative.

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -117,7 +117,7 @@ mod tmp_pub {
         pub fn builder() -> Builder { Builder::new() }
 
         /// Generates OP_RETURN-type of scriptPubkey for the given data.
-        pub fn new_op_return<T: AsRef<PushBytes>>(data: T) -> Self {
+        pub fn new_op_return(data: impl AsRef<PushBytes>) -> Self {
             Builder::new().push_opcode(OP_RETURN).push_slice(data).into_script()
         }
 
@@ -131,7 +131,7 @@ mod tmp_pub {
         pub fn push_opcode(&mut self, data: Opcode) { self.push(data.to_u8()); }
 
         /// Adds instructions to push some arbitrary data onto the stack.
-        pub fn push_slice<T: AsRef<PushBytes>>(&mut self, data: T) {
+        pub fn push_slice(&mut self, data: impl AsRef<PushBytes>) {
             let data = data.as_ref();
             self.reserve(Self::reserved_len_for_slice(data.len()));
             self.push_slice_no_opt(data);

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -112,127 +112,127 @@ impl ScriptBuf {
 
 mod tmp_pub {
     use super::*;
-impl ScriptBuf {
-    /// Creates a new script builder
-    pub fn builder() -> Builder { Builder::new() }
+    impl ScriptBuf {
+        /// Creates a new script builder
+        pub fn builder() -> Builder { Builder::new() }
 
-    /// Generates OP_RETURN-type of scriptPubkey for the given data.
-    pub fn new_op_return<T: AsRef<PushBytes>>(data: T) -> Self {
-        Builder::new().push_opcode(OP_RETURN).push_slice(data).into_script()
-    }
-
-    /// Creates a [`ScriptBuf`] from a hex string.
-    pub fn from_hex(s: &str) -> Result<Self, hex::HexToBytesError> {
-        let v = Vec::from_hex(s)?;
-        Ok(ScriptBuf::from_bytes(v))
-    }
-
-    /// Adds a single opcode to the script.
-    pub fn push_opcode(&mut self, data: Opcode) { self.push(data.to_u8()); }
-
-    /// Adds instructions to push some arbitrary data onto the stack.
-    pub fn push_slice<T: AsRef<PushBytes>>(&mut self, data: T) {
-        let data = data.as_ref();
-        self.reserve(Self::reserved_len_for_slice(data.len()));
-        self.push_slice_no_opt(data);
-    }
-
-    /// Add a single instruction to the script.
-    ///
-    /// # Panics
-    ///
-    /// The method panics if the instruction is a data push with length greater or equal to
-    /// 0x100000000.
-    pub fn push_instruction(&mut self, instruction: Instruction<'_>) {
-        match instruction {
-            Instruction::Op(opcode) => self.push_opcode(opcode),
-            Instruction::PushBytes(bytes) => self.push_slice(bytes),
+        /// Generates OP_RETURN-type of scriptPubkey for the given data.
+        pub fn new_op_return<T: AsRef<PushBytes>>(data: T) -> Self {
+            Builder::new().push_opcode(OP_RETURN).push_slice(data).into_script()
         }
-    }
 
-    /// Like push_instruction, but avoids calling `reserve` to not re-check the length.
-    pub fn push_instruction_no_opt(&mut self, instruction: Instruction<'_>) {
-        match instruction {
-            Instruction::Op(opcode) => self.push_opcode(opcode),
-            Instruction::PushBytes(bytes) => self.push_slice_no_opt(bytes),
+        /// Creates a [`ScriptBuf`] from a hex string.
+        pub fn from_hex(s: &str) -> Result<Self, hex::HexToBytesError> {
+            let v = Vec::from_hex(s)?;
+            Ok(ScriptBuf::from_bytes(v))
         }
-    }
 
-    /// Adds an `OP_VERIFY` to the script or replaces the last opcode with VERIFY form.
-    ///
-    /// Some opcodes such as `OP_CHECKSIG` have a verify variant that works as if `VERIFY` was
-    /// in the script right after. To save space this function appends `VERIFY` only if
-    /// the most-recently-added opcode *does not* have an alternate `VERIFY` form. If it does
-    /// the last opcode is replaced. E.g., `OP_CHECKSIG` will become `OP_CHECKSIGVERIFY`.
-    ///
-    /// Note that existing `OP_*VERIFY` opcodes do not lead to the instruction being ignored
-    /// because `OP_VERIFY` consumes an item from the stack so ignoring them would change the
-    /// semantics.
-    ///
-    /// This function needs to iterate over the script to find the last instruction. Prefer
-    /// `Builder` if you're creating the script from scratch or if you want to push `OP_VERIFY`
-    /// multiple times.
-    pub fn scan_and_push_verify(&mut self) { self.push_verify(self.last_opcode()); }
-}
+        /// Adds a single opcode to the script.
+        pub fn push_opcode(&mut self, data: Opcode) { self.push(data.to_u8()); }
+
+        /// Adds instructions to push some arbitrary data onto the stack.
+        pub fn push_slice<T: AsRef<PushBytes>>(&mut self, data: T) {
+            let data = data.as_ref();
+            self.reserve(Self::reserved_len_for_slice(data.len()));
+            self.push_slice_no_opt(data);
+        }
+
+        /// Add a single instruction to the script.
+        ///
+        /// # Panics
+        ///
+        /// The method panics if the instruction is a data push with length greater or equal to
+        /// 0x100000000.
+        pub fn push_instruction(&mut self, instruction: Instruction<'_>) {
+            match instruction {
+                Instruction::Op(opcode) => self.push_opcode(opcode),
+                Instruction::PushBytes(bytes) => self.push_slice(bytes),
+            }
+        }
+
+        /// Like push_instruction, but avoids calling `reserve` to not re-check the length.
+        pub fn push_instruction_no_opt(&mut self, instruction: Instruction<'_>) {
+            match instruction {
+                Instruction::Op(opcode) => self.push_opcode(opcode),
+                Instruction::PushBytes(bytes) => self.push_slice_no_opt(bytes),
+            }
+        }
+
+        /// Adds an `OP_VERIFY` to the script or replaces the last opcode with VERIFY form.
+        ///
+        /// Some opcodes such as `OP_CHECKSIG` have a verify variant that works as if `VERIFY` was
+        /// in the script right after. To save space this function appends `VERIFY` only if
+        /// the most-recently-added opcode *does not* have an alternate `VERIFY` form. If it does
+        /// the last opcode is replaced. E.g., `OP_CHECKSIG` will become `OP_CHECKSIGVERIFY`.
+        ///
+        /// Note that existing `OP_*VERIFY` opcodes do not lead to the instruction being ignored
+        /// because `OP_VERIFY` consumes an item from the stack so ignoring them would change the
+        /// semantics.
+        ///
+        /// This function needs to iterate over the script to find the last instruction. Prefer
+        /// `Builder` if you're creating the script from scratch or if you want to push `OP_VERIFY`
+        /// multiple times.
+        pub fn scan_and_push_verify(&mut self) { self.push_verify(self.last_opcode()); }
+    }
 }
 
 mod tmp_priv {
     use super::*;
-impl ScriptBuf {
-    /// Pushes the slice without reserving
-    pub(in crate::blockdata::script) fn push_slice_no_opt(&mut self, data: &PushBytes) {
-        // Start with a PUSH opcode
-        match data.len().to_u64() {
-            n if n < opcodes::Ordinary::OP_PUSHDATA1 as u64 => {
-                self.push(n as u8);
+    impl ScriptBuf {
+        /// Pushes the slice without reserving
+        pub(in crate::blockdata::script) fn push_slice_no_opt(&mut self, data: &PushBytes) {
+            // Start with a PUSH opcode
+            match data.len().to_u64() {
+                n if n < opcodes::Ordinary::OP_PUSHDATA1 as u64 => {
+                    self.push(n as u8);
+                }
+                n if n < 0x100 => {
+                    self.push(opcodes::Ordinary::OP_PUSHDATA1.to_u8());
+                    self.push(n as u8);
+                }
+                n if n < 0x10000 => {
+                    self.push(opcodes::Ordinary::OP_PUSHDATA2.to_u8());
+                    self.push((n % 0x100) as u8);
+                    self.push((n / 0x100) as u8);
+                }
+                // `PushBytes` enforces len < 0x100000000
+                n => {
+                    self.push(opcodes::Ordinary::OP_PUSHDATA4.to_u8());
+                    self.push((n % 0x100) as u8);
+                    self.push(((n / 0x100) % 0x100) as u8);
+                    self.push(((n / 0x10000) % 0x100) as u8);
+                    self.push((n / 0x1000000) as u8);
+                }
             }
-            n if n < 0x100 => {
-                self.push(opcodes::Ordinary::OP_PUSHDATA1.to_u8());
-                self.push(n as u8);
-            }
-            n if n < 0x10000 => {
-                self.push(opcodes::Ordinary::OP_PUSHDATA2.to_u8());
-                self.push((n % 0x100) as u8);
-                self.push((n / 0x100) as u8);
-            }
-            // `PushBytes` enforces len < 0x100000000
-            n => {
-                self.push(opcodes::Ordinary::OP_PUSHDATA4.to_u8());
-                self.push((n % 0x100) as u8);
-                self.push(((n / 0x100) % 0x100) as u8);
-                self.push(((n / 0x10000) % 0x100) as u8);
-                self.push((n / 0x1000000) as u8);
-            }
+            // Then push the raw bytes
+            self.extend_from_slice(data.as_bytes());
         }
-        // Then push the raw bytes
-        self.extend_from_slice(data.as_bytes());
-    }
 
-    /// Computes the sum of `len` and the length of an appropriate push opcode.
-    pub(in crate::blockdata::script) fn reserved_len_for_slice(len: usize) -> usize {
-        len + match len {
-            0..=0x4b => 1,
-            0x4c..=0xff => 2,
-            0x100..=0xffff => 3,
-            // we don't care about oversized, the other fn will panic anyway
-            _ => 5,
-        }
-    }
-
-    /// Adds an `OP_VERIFY` to the script or changes the most-recently-added opcode to `VERIFY`
-    /// alternative.
-    ///
-    /// See the public fn [`Self::scan_and_push_verify`] to learn more.
-    pub(in crate::blockdata::script) fn push_verify(&mut self, last_opcode: Option<Opcode>) {
-        match opcode_to_verify(last_opcode) {
-            Some(opcode) => {
-                self.pop();
-                self.push_opcode(opcode);
+        /// Computes the sum of `len` and the length of an appropriate push opcode.
+        pub(in crate::blockdata::script) fn reserved_len_for_slice(len: usize) -> usize {
+            len + match len {
+                0..=0x4b => 1,
+                0x4c..=0xff => 2,
+                0x100..=0xffff => 3,
+                // we don't care about oversized, the other fn will panic anyway
+                _ => 5,
             }
-            None => self.push_opcode(OP_VERIFY),
+        }
+
+        /// Adds an `OP_VERIFY` to the script or changes the most-recently-added opcode to `VERIFY`
+        /// alternative.
+        ///
+        /// See the public fn [`Self::scan_and_push_verify`] to learn more.
+        pub(in crate::blockdata::script) fn push_verify(&mut self, last_opcode: Option<Opcode>) {
+            match opcode_to_verify(last_opcode) {
+                Some(opcode) => {
+                    self.pop();
+                    self.push_opcode(opcode);
+                }
+                None => self.push_opcode(OP_VERIFY),
+            }
         }
     }
-}
 }
 
 impl<'a> core::iter::FromIterator<Instruction<'a>> for ScriptBuf {

--- a/bitcoin/src/crypto/ecdsa.rs
+++ b/bitcoin/src/crypto/ecdsa.rs
@@ -13,6 +13,8 @@ use io::Write;
 
 use crate::prelude::{DisplayHex, Vec};
 use crate::script::PushBytes;
+#[cfg(doc)]
+use crate::script::ScriptBufExt as _;
 use crate::sighash::{EcdsaSighashType, NonStandardSighashTypeError};
 
 const MAX_SIG_LEN: usize = 73;

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1470,6 +1470,7 @@ mod tests {
     use super::*;
     use crate::consensus::deserialize;
     use crate::locktime::absolute;
+    use crate::script::ScriptBufExt as _;
 
     extern crate serde_json;
 

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1216,7 +1216,7 @@ mod tests {
     use crate::locktime::absolute;
     use crate::network::NetworkKind;
     use crate::psbt::serialize::{Deserialize, Serialize};
-    use crate::script::ScriptBuf;
+    use crate::script::{ScriptBuf, ScriptBufExt as _};
     use crate::transaction::{self, OutPoint, TxIn};
     use crate::witness::Witness;
     use crate::Sequence;

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -383,6 +383,7 @@ fn key_source_len(key_source: &KeySource) -> usize { 4 + 4 * (key_source.1).as_r
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::script::ScriptBufExt as _;
 
     // Composes tree matching a given depth map, filled with dumb script leafs,
     // each of which consists of a single push-int op code, with int value

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -1544,6 +1544,7 @@ mod test {
     use secp256k1::VerifyOnly;
 
     use super::*;
+    use crate::script::ScriptBufExt as _;
     use crate::sighash::{TapSighash, TapSighashTag};
     use crate::{Address, KnownHrp};
     extern crate serde_json;

--- a/bitcoin/tests/bip_174.rs
+++ b/bitcoin/tests/bip_174.rs
@@ -9,7 +9,7 @@ use bitcoin::consensus::encode::{deserialize, serialize_hex};
 use bitcoin::hex::FromHex;
 use bitcoin::opcodes::OP_0;
 use bitcoin::psbt::{Psbt, PsbtSighashType};
-use bitcoin::script::PushBytes;
+use bitcoin::script::{PushBytes, ScriptBufExt as _};
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::{
     absolute, script, transaction, Amount, Denomination, NetworkKind, OutPoint, PrivateKey,

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -33,6 +33,7 @@ use bitcoin::hex::FromHex;
 use bitcoin::locktime::{absolute, relative};
 use bitcoin::psbt::raw::{self, Key, Pair, ProprietaryKey};
 use bitcoin::psbt::{Input, Output, Psbt, PsbtSighashType};
+use bitcoin::script::ScriptBufExt;
 use bitcoin::sighash::{EcdsaSighashType, TapSighashType};
 use bitcoin::taproot::{self, ControlBlock, LeafVersion, TapTree, TaprootBuilder};
 use bitcoin::witness::Witness;


### PR DESCRIPTION
I felt like writing up the change. You probably want to incorporate it into previous history rather than leaving things change back and forth.

A public API even if hidden has potential compatibility risks that we want to avoid. We could come up with better API but we can simply workaround it by temporarily swapping the script with an empty one, then modifying the vec and then swapping it back.